### PR TITLE
修复了 bilibili 应用未安装情况下点击视频不会复制 bv 号的问题

### DIFF
--- a/app/src/main/java/com/example/asasfans/ui/main/adapter/PubdateVideoAdapter.java
+++ b/app/src/main/java/com/example/asasfans/ui/main/adapter/PubdateVideoAdapter.java
@@ -154,6 +154,14 @@ public class PubdateVideoAdapter extends RecyclerView.Adapter<VideoViewHolder> {
                 dialog.show();
             }
         });
+        
+        // 实现复制 bv 号到剪贴板的复用
+        public void copy2Pasteboard() {
+            ClipboardManager cm = (ClipboardManager) mContext.getSystemService(Context.CLIPBOARD_SERVICE);
+            ClipData mClipData = ClipData.newPlainText("bvid", videoDataStoragedInMemoryList.get(videoViewHolder.getBindingAdapterPosition()).getBvid());
+            cm.setPrimaryClip(mClipData);
+        }
+
         view.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -172,6 +180,8 @@ public class PubdateVideoAdapter extends RecyclerView.Adapter<VideoViewHolder> {
                     mContext.startActivity(it);
                 }else {
                     Toast.makeText(mContext,"没有bilibili，已复制bv号",Toast.LENGTH_SHORT).show();
+                    copy2Pasteboard();
+                    // TODO 通过浏览器打开链接
                 }
 
             }
@@ -181,9 +191,7 @@ public class PubdateVideoAdapter extends RecyclerView.Adapter<VideoViewHolder> {
             public boolean onLongClick(View v) {
                 Toast.makeText(mContext,videoDataStoragedInMemoryList.get(videoViewHolder.getBindingAdapterPosition()).getBvid() + "已复制到剪贴板",Toast.LENGTH_SHORT).show();
                 //获取剪贴板管理器：
-                ClipboardManager cm = (ClipboardManager) mContext.getSystemService(Context.CLIPBOARD_SERVICE);
-                ClipData mClipData = ClipData.newPlainText("bvid", videoDataStoragedInMemoryList.get(videoViewHolder.getBindingAdapterPosition()).getBvid());
-                cm.setPrimaryClip(mClipData);
+                copy2Pasteboard();
                 return true;
             }
         });


### PR DESCRIPTION
警告：因为本地没有安装 Android Stuido，所以没有运行过，请帮忙检查后再合并（在线编辑导致缩进也有问题）。
1. 修复了 bilibili 应用未安装情况下点击视频不会复制 bv 号的问题
2. 增加了方便复用的函数
3. 增加了 bilibili 应用未安装情况下使用浏览器打开视频的 TODO