### PR TITLE
fix(ImageDataBean): 修改 'uid' 类型为 long

### DIFF
--- a/app/src/main/java/com/example/asasfans/data/ImageDataBean.java
+++ b/app/src/main/java/com/example/asasfans/data/ImageDataBean.java
@@ -18,7 +18,7 @@ public class ImageDataBean {
      */
 
     private String dy_id;
-    private int uid;
+    private long uid;
     private String name;
     private String face;
     private List<PicUrlBean> pic_url;
@@ -31,11 +31,11 @@ public class ImageDataBean {
         this.dy_id = dy_id;
     }
 
-    public int getUid() {
+    public long getUid() {
         return uid;
     }
 
-    public void setUid(int uid) {
+    public void setUid(long uid) {
         this.uid = uid;
     }
 


### PR DESCRIPTION
因部分用户 'uid' 过长，使用 'int' 类型保存 'uid' 会导致 gson 反序列化时出现 NumberFormatException 导致APP崩溃。
相关 API 接口: https://api.asoul.cloud:8000/getPic?page=1&sort=3